### PR TITLE
Add custom accordion

### DIFF
--- a/app/assets/images/icons/accordion-close.svg
+++ b/app/assets/images/icons/accordion-close.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="5" viewBox="0 0 16 5" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 4.40405V0.404053L0 0.404053V4.40405L16 4.40405Z" fill="#0B0C0C"/>
+</svg>

--- a/app/assets/images/icons/accordion-open.svg
+++ b/app/assets/images/icons/accordion-open.svg
@@ -1,0 +1,11 @@
+<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_809_1199)">
+<path d="M16 10.4041V6.40405L0 6.40405V10.4041H16Z" fill="#0B0C0C"/>
+<path d="M6 16.4041L10 16.4041L10 0.404053L6 0.404052L6 16.4041Z" fill="#0B0C0C"/>
+</g>
+<defs>
+<clipPath id="clip0_809_1199">
+<rect width="16" height="16" fill="white" transform="translate(0 0.404053)"/>
+</clipPath>
+</defs>
+</svg>

--- a/app/assets/javascripts/accordion.js
+++ b/app/assets/javascripts/accordion.js
@@ -1,0 +1,11 @@
+$(document).ready(function () {
+  if (document.getElementById('accordion') !== null) {
+    var buttons = document.querySelectorAll('.accordion-heading')
+
+    buttons.forEach(function (b) {
+      b.addEventListener('click', function (e) {
+        e.target.closest('.accordion-section').classList.toggle('open')
+      })
+    })
+  }
+})

--- a/app/assets/sass/accordion.scss
+++ b/app/assets/sass/accordion.scss
@@ -1,0 +1,48 @@
+.accordion-section {
+  border-top: 1px solid #b1b4b6;
+
+  .icon-open {
+    display: block;
+  }
+
+  .icon-close {
+    display: none;
+  }
+  .accordion-body {
+    margin-bottom: 2rem;
+    display: none;
+
+  }
+
+  &.open {
+    .accordion-body {
+      display: block;
+    }
+
+    .icon-open {
+      display: none;
+    }
+
+    .icon-close {
+      display: block;
+    }
+  }
+}
+
+.accordion-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+  cursor: pointer;
+
+  h3 {
+    margin: 0;
+    color: #2E65B7;
+  }
+}
+
+.accordion-toggle {
+  padding: 0 0.5rem;
+  margin-left: 2rem;
+}

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -19,6 +19,7 @@ $govuk-font-family: Lexend, "HelveticaNeue", "Helvetica Neue", "Arial", "Helveti
 
 // fg code
 @import "cookie-banner";
+@import "accordion";
 @import "ecc-button";
 @import "search-container";
 @import "hero";

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -7,6 +7,7 @@
 
 <script src="/public/javascripts/application.js"></script>
 <script src="/public/javascripts/cookie-consent.js"></script>
+<script src="/public/javascripts/accordion.js"></script>
 
 {% if useAutoStoreData %}
   <script src="/public/javascripts/auto-store-data.js"></script>

--- a/app/views/leave-allowance.html
+++ b/app/views/leave-allowance.html
@@ -1,302 +1,295 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Leave allowance - Essex Intranet Prototype
+Leave allowance - Essex Intranet Prototype
 {% endblock %}
 
 
 
 {% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="index">Home</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="level-01">Leave and time off</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="level-02">Annual leave</a>
-      </li>
-    </ol>
-  </div>
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="index">Home</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="level-01">Leave and time off</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="level-02">Annual leave</a>
+    </li>
+  </ol>
+</div>
 {% endblock %}
 
 
 {% block content %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds" style="padding-right:40px">
-  <!-- Block text starts -->
-      <div class="timestamp">Last updated: Wed 02 Feb 2022</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds" style="padding-right:40px">
+    <!-- Block text starts -->
+    <div class="timestamp">Last updated: Wed 02 Feb 2022</div>
 
-      <h1 class="govuk-heading-xl">
-        Annual leave allowance
-      </h1>
+    <h1 class="govuk-heading-xl">
+      Annual leave allowance
+    </h1>
 
 
-  <!-- Block text ends -->
+    <!-- Block text ends -->
 
-  <!-- Block text starts -->
+    <!-- Block text starts -->
 
-  <div class="txtblock">
+    <div class="txtblock">
       <p>
-        How much annual leave you get is written in your contract.
-        <br>It depends on:
-</p>
-        <ul class="">
-          <li>conditions of service</li>
-          <li>salary</li>
-          <li>length of service.</li>
+      How much annual leave you get is written in your contract.
+      <br>It depends on:
+      </p>
+      <ul class="">
+        <li>conditions of service</li>
+        <li>salary</li>
+        <li>length of service.</li>
+      </ul>
+      <p>Due to the various different types of contracts within the organisation, you can check your annual leave entitlement in our <a href="public//images/Holiday_policy.pdf" target="_blank">Holiday Policy (PDF, 165KB)</a> or check your contract.</p>
+
+    </div>
+
+    <!-- Block text ends -->
+
+
+
+    <!-- Block Calculator starts -->
+    <div class="txtblock calculator"  style="" >
+      <div class="govuk-form-group">
+        <form id="form">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h3 style="padding-left:50px">Holiday allowance calculator</h3>
+            </legend>
+
+            <div class="govuk-radios" data-module="govuk-radios">
+              <p><b>What's your employment contract based on?</b></p>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="contract-type" name="contract-type" type="radio" value="1">
+                <label class="govuk-label govuk-radios__label" for="1">
+                  days worked per week
+                </label>
+              </div>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="contract-type" name="contract-type" type="radio" value="2">
+                <label class="govuk-label govuk-radios__label" for="2">
+                  hours worked per week
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="contract-type" name="contract-type" type="radio" value="3">
+                <label class="govuk-label govuk-radios__label" for="3">
+                  casual or irregular hours, including zero hours contracts
+                </label>
+              </div>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="contract-type" name="contract-type" type="radio" value="4">
+                <label class="govuk-label govuk-radios__label" for="4">
+                  annualised hours
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="contract-type" name="contract-type" type="radio" value="5">
+                <label class="govuk-label govuk-radios__label" for="5">
+                  compressed hours
+                </label>
+              </div>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="contract-type" name="contract-type" type="radio" value="6">
+                <label class="govuk-label govuk-radios__label" for="where-do-you-live">
+                  shifts
+                </label>
+              </div>
+            </div>
+
+          </fieldset>
+
+          <input type="submit" value="Continue" class="button button2 govuk-!-margin-top-4" style="height:50px">
+
+        </form>
+      </div>
+    </div>
+    <!-- Block Calculator ends -->
+
+
+    <!-- Block text starts -->
+    <div class="txtblock">
+      <h2>Find out how much annual leave you currently have</h2>
+      <p>You can check how much holiday you have on <b>My Oracle</b>.
+      Sign in and select ‘Time and absences’ then ‘Absence balance’.</p>
+
+      <p>Your absence balance is shown in hours and will include:</p>
+      <ul class="">
+        <li>any holiday hours that you have bought</li>
+        <li>bank holiday hours if you work part-time</li>
+        <li>a deduction for any approved annual leave</li>
+      </ul>
+
+      <button class="button button2">
+        <a href="https://fa-epwc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/faces/FndOverview?fndGlobalItemNodeId=itemNode_my_information_absences1" target="_blank">
+          Check annual leave allowance</a>
+        <img alt="" style="width: 24px;margin-left:12px;padding-top:0px" src="public/images/icons/external-link-icon.svg">
+      </button>
+    </div>
+    <!-- Block text ends -->
+
+
+
+    <!-- Block accordion starts -->
+    <div id='accordion'>
+      <div class='accordion-section open'>
+        <div id='accordion-heading-1' class='accordion-heading'>
+          <h3>
+            Additional annual leave
+          </h3>
+          <div class='accordion-toggle'>
+            <img class='icon-open' alt='' src='/public/images/icons/accordion-open.svg'>
+            <img class='icon-close' alt='' src='/public/images/icons/accordion-close.svg'>
+          </div>
+        </div>
+
+        <div id='accordion-body-1' class='accordion-body'>
+          <p>You’re allowed to <a href="#">carry over some annual leave to the following year</a>. This will be included in your balance.</p>
+          <p>You can also <a href="buy-leave">buy more holiday</a>. This will be included in your balance.</p>
+          <p>Managers may award up to two extra day’s holiday for employees who demonstrate an exceptional level of performance.  This is managed between you and your line manager, and not included in your balance.</p>
+        </div>
+      </div>
+
+      <div class='accordion-section'>
+        <div id='accordion-heading-2' class='accordion-heading'>
+          <h3>
+            Annual leave and maternity or shared parental leave
+          </h3>
+          <div class='accordion-toggle'>
+            <img class='icon-open' alt='' src='/public/images/icons/accordion-open.svg'>
+            <img class='icon-close' alt='' src='/public/images/icons/accordion-close.svg'>
+          </div>
+        </div>
+
+        <div id='accordion-body-2' class='accordion-body'>
+          <p>Your annual leave entitlement builds up each month during your first year of employment. This is at a rate of 1/12th of your annual leave entitlement.</p>
+          <p>If you book annual leave during your first month, you may be restricted by the amount of leave that has been built up.
+            Your line manager may allow you to take more, subject to operational requirements.</p>
+          <p>We will try to honour commitments to pre-booked holidays.</p>
+          <p>After your first year, you can take your full leave entitlement from the beginning of the leave year.</p>
+        </div>
+      </div>
+
+      <div class='accordion-section'>
+        <div id='accordion-heading-3' class='accordion-heading'>
+          <h3>
+            Annual leave for new starters
+          </h3>
+          <div class='accordion-toggle'>
+            <img class='icon-open' alt='' src='/public/images/icons/accordion-open.svg'>
+            <img class='icon-close' alt='' src='/public/images/icons/accordion-close.svg'>
+          </div>
+        </div>
+
+        <div id='accordion-body-3' class='accordion-body'>
+          <p>Your annual leave entitlement builds up each month during your first year of employment. This is at a rate of 1/12th of your annual leave entitlement.</p>
+          <p>If you book annual leave during your first month, you may be restricted by the amount of leave that has been built up.
+            Your line manager may allow you to take more, subject to operational requirements.</p>
+          <p>We will try to honour commitments to pre-booked holidays.</p>
+          <p>After your first year, you can take your full leave entitlement from the beginning of the leave year.</p>
+        </div>
+      </div>
+
+      <div class='accordion-section'>
+        <div id='accordion-heading-4' class='accordion-heading'>
+          <h3>
+            Annual leave for leavers
+          </h3>
+          <div class='accordion-toggle'>
+            <img class='icon-open' alt='' src='/public/images/icons/accordion-open.svg'>
+            <img class='icon-close' alt='' src='/public/images/icons/accordion-close.svg'>
+          </div>
+        </div>
+
+        <div id='accordion-body-4' class='accordion-body'>
+          <p>Your annual leave entitlement builds up each month during your first year of employment. This is at a rate of 1/12th of your annual leave entitlement.</p>
+          <p>If you book annual leave during your first month, you may be restricted by the amount of leave that has been built up.
+            Your line manager may allow you to take more, subject to operational requirements.</p>
+          <p>We will try to honour commitments to pre-booked holidays.</p>
+          <p>After your first year, you can take your full leave entitlement from the beginning of the leave year.</p>
+        </div>
+      </div>
+
+      <div class='accordion-section'>
+        <div id='accordion-heading-5' class='accordion-heading'>
+          <h3>
+            Illness while on annual leave
+          </h3>
+          <div class='accordion-toggle'>
+            <img class='icon-open' alt='' src='/public/images/icons/accordion-open.svg'>
+            <img class='icon-close' alt='' src='/public/images/icons/accordion-close.svg'>
+          </div>
+        </div>
+
+        <div id='accordion-body-5' class='accordion-body'>
+          <p>Your annual leave entitlement builds up each month during your first year of employment. This is at a rate of 1/12th of your annual leave entitlement.</p>
+          <p>If you book annual leave during your first month, you may be restricted by the amount of leave that has been built up.
+            Your line manager may allow you to take more, subject to operational requirements.</p>
+          <p>We will try to honour commitments to pre-booked holidays.</p>
+          <p>After your first year, you can take your full leave entitlement from the beginning of the leave year.</p>
+        </div>
+      </div>
+    </div>
+    <!-- Block accordion ends -->
+
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <aside class="app-related-items" role="complementary">
+      <h2 class="govuk-heading-m" id="subsection-title">
+        In this section
+      </h2>
+      <nav role="navigation" aria-labelledby="subsection-title">
+        <ul class="govuk-list govuk-!-font-size-16">
+          <li>
+            <a href="book-leave">
+              Book annual leave
+            </a>
+          </li>
+
+          <li>
+            <a href="#">
+              Change annual leave
+            </a>
+          </li>
+
+          <li>
+            <a href="buy-leave" class="govuk-!-font-weight-bold">
+              Buy more annual leave
+            </a>
+          </li>
+
+
+          <li>
+            <a href="#">
+              Carry over annual leave
+            </a>
+          </li>
+          <li class="active">
+            Annual leave allowance
+          </li>
+
         </ul>
-        <p>Due to the various different types of contracts within the organisation, you can check your annual leave entitlement in our <a href="public//images/Holiday_policy.pdf" target="_blank">Holiday Policy</a> (PDF, 165KB) or check your contract.</p>
+      </nav>
+    </aside>
 
+    {% include "includes/contact-help.html" %}
   </div>
-
-<!-- Block text ends -->
-
-
-
-<!-- Block Calculator starts -->
-
-  <div class="txtblock calculator"  style="" >
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <h3 style="padding-left:50px">Holiday allowance calculator</h3>
-        </legend>
-        <div class="govuk-radios" data-module="govuk-radios">
-          <p><b>What's your employment contract based on?</b></p>
-
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="contract-type" name="contract-type" type="radio" value="1">
-            <label class="govuk-label govuk-radios__label" for="1">
-              days worked per week
-            </label>
-          </div>
-
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="contract-type" name="contract-type" type="radio" value="2">
-            <label class="govuk-label govuk-radios__label" for="2">
-              hours worked per week
-            </label>
-          </div>
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="contract-type" name="contract-type" type="radio" value="3">
-            <label class="govuk-label govuk-radios__label" for="3">
-              casual or irregular hours, including zero hours contracts
-            </label>
-          </div>
-
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="contract-type" name="contract-type" type="radio" value="4">
-            <label class="govuk-label govuk-radios__label" for="4">
-              annualised hours
-            </label>
-          </div>
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="contract-type" name="contract-type" type="radio" value="5">
-            <label class="govuk-label govuk-radios__label" for="5">
-              compressed hours
-            </label>
-          </div>
-
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="contract-type" name="contract-type" type="radio" value="6">
-            <label class="govuk-label govuk-radios__label" for="where-do-you-live">
-              shifts
-            </label>
-          </div>
-
-      </fieldset>
-    </div>
-
-  <form id="form">
-
-
-<p></p>
-    <input type="submit" value="Continue" class="button button2" style="height:50px">
-
-  </form>
-
 
 </div>
-<!-- Block Calculator ends -->
-
-
-<!-- Block text starts -->
-
-<div class="txtblock">
-  <h2>Find out how much annual leave you currently have</h2>
-  <p>You can check how much holiday you have on <b>My Oracle</b>.
-    Sign in and select ‘Time and absences’ then ‘Absence balance’.</p>
-
-  <p>Your absence balance is shown in hours and will include:</p>
-  <ul class="">
-    <li>any holiday hours that you have bought</li>
-    <li>bank holiday hours if you work part-time</li>
-    <li>a deduction for any approved annual leave</li>
-  </ul>
-
-  <button class="button button2">
-  <a href="https://fa-epwc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/faces/FndOverview?fndGlobalItemNodeId=itemNode_my_information_absences1" target="_blank">
-    Check annual leave allowance</a>
-    <img class="" style="width: 24px;margin-left:12px;padding-top:0px" src="public/images/icons/external-link-icon.svg">
-  </button>
-</div>
-  <!-- Block text ends -->
-
-
-
-<!-- Block text starts -->
-  <div class="txtblock">
-    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-  <div class="govuk-accordion__section ">
-    <div class="govuk-accordion__section-header">
-      <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
-          Additional annual leave
-        </span>
-      </h2>
-    </div>
-    <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
-      <p class='govuk-body'>You’re allowed to <a href="#">carry over some annual leave to the following year</a>. This will be included in your balance.
-      <p>You can also <a href="buy-leave">buy more holiday</a>. This will be included in your balance.</p>
-      <p>Managers may award up to two extra day’s holiday for employees who demonstrate an exceptional level of performance.  This is managed between you and your line manager, and not included in your balance.</p>
-
-
-    </div>
-  </div>
-  <div class="govuk-accordion__section ">
-    <div class="govuk-accordion__section-header">
-      <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-          Annual leave and maternityor shared parental leave
-        </span>
-      </h2>
-    </div>
-    <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-      <p class='govuk-body'>Your annual leave entitlement builds up each month during your first year of employment. This is at a rate of 1/12th of your annual leave entitlement.  </p>
-      <p>If you book annual leave during your first month, you may be restricted by the amount of leave that has been built up.
-      Your line manager may allow you to take more, subject to operational requirements.  </p>
-      <p>We will try to honour commitments to pre-booked holidays.  </p>
-      <p>After your first year, you can take your full leave entitlement from the beginning of the leave year. </p>
-
-    </div>
-  </div>
-  <div class="govuk-accordion__section ">
-    <div class="govuk-accordion__section-header">
-      <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
-          Annual leave for new starters
-        </span>
-      </h2>
-    </div>
-    <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
-      <p>Your annual leave entitlement builds up each month during your first year of employment. This is at a rate of 1/12th of your annual leave entitlement.</p>
-      <p>If you book annual leave during your first month, you may be restricted by the amount of leave that has been built up.
-      Your line manager may allow you to take more, subject to operational requirements.</p>
-      <p>We will try to honour commitments to pre-booked holidays.</p>
-      <p>After your first year, you can take your full leave entitlement from the beginning of the leave year. </p>
-    </div>
-  </div>
-  <div class="govuk-accordion__section ">
-    <div class="govuk-accordion__section-header">
-      <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
-          Annual leave for leavers
-        </span>
-      </h2>
-    </div>
-    <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
-      <p>Your annual leave entitlement builds up each month during your first year of employment. This is at a rate of 1/12th of your annual leave entitlement.</p>
-      <p>If you book annual leave during your first month, you may be restricted by the amount of leave that has been built up.  </p>
-      <p>Your line manager may allow you to take more, subject to operational requirements.</p>
-      <p>We will try to honour commitments to pre-booked holidays.  </p>
-      <p>After your first year, you can take your full leave entitlement from the beginning of the leave year.</p>
-      <p>After your first year, you can take your full leave entitlement from the beginning of the leave year.</p>
-    </div>
-  </div>
-
-  <div class="govuk-accordion__section ">
-    <div class="govuk-accordion__section-header">
-      <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
-          Annual leave for leavers
-        </span>
-      </h2>
-    </div>
-    <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
-      <p>Your annual leave entitlement builds up each month during your first year of employment. This is at a rate of 1/12th of your annual leave entitlement.</p>
-      <p>If you book annual leave during your first month, you may be restricted by the amount of leave that has been built up.
-        <p>Your line manager may allow you to take more, subject to operational requirements.</p>
-        <p>We will try to honour commitments to pre-booked holidays.</p>
-        <p>After your first year, you can take your full leave entitlement from the beginning of the leave year. </p>
-
-    </div>
-  </div>
-
-
-
-</div>
-  </div>
-<!-- Block text ends -->
-
-<!-- Block text starts -->
-<div class="txtblock">
-    <h2>Guidance for line managers</h2>
-    <a href="public/images/Holiday_buying_additional_line_manager_guide.pdf" target="_blank" >
-    <img src="public/images/icons/arrow.svg" style="margin:0px 8px 0 0">View and download pdf guidance</a>
-</div>
-<!-- Block text ends -->
-
-
-
-    </div>
-    <div class="govuk-grid-column-one-third">
-
-      <aside class="app-related-items" role="complementary">
-        <h2 class="govuk-heading-m" id="subsection-title">
-          In this section
-        </h2>
-        <nav role="navigation" aria-labelledby="subsection-title">
-          <ul class="govuk-list govuk-!-font-size-16">
-            <li>
-              <a href="book-leave">
-                Book annual leave
-              </a>
-            </li>
-
-            <li>
-              <a href="#">
-                Change annual leave
-              </a>
-            </li>
-
-            <li>
-              <a href="buy-leave" class="govuk-!-font-weight-bold">
-                Buy more annual leave
-              </a>
-            </li>
-
-
-            <li>
-              <a href="#">
-                Carry over annual leave
-              </a>
-            </li>
-            <li class="active">
-                Annual leave allowance
-            </li>
-
-          </ul>
-        </nav>
-      </aside>
-
-      {% include "includes/contact-help.html" %}
-    </div>
-
-  </div>
 
 <div style="height:80px"></div>
 


### PR DESCRIPTION
I decided it was too much work to try and modify the GOV.UK accordion because it was adding all sorts of elements we didn't want with JS, so instead we now have a custom accordion in line with the designs.

It doesn't do anything too fancy e.g. closing all the other sections when you open one, but it should do the trick for the prototype!

<img width="930" alt="Screenshot 2022-02-08 at 15 52 52" src="https://user-images.githubusercontent.com/11888656/153012071-1255ab75-70ba-4960-ad5a-f0edc39043ea.png">
.