### PR TITLE
Mobile responsive styles

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -25,16 +25,16 @@ $govuk-font-family: Lexend, "HelveticaNeue", "Helvetica Neue", "Arial", "Helveti
 @import "hero";
 
 .govuk-grid-column-one-quarter{
-	padding-right:4px;
+  padding-right:4px;
 }
 
 body {
-font-family: Lexend, calibri, helvetica;
+  font-family: Lexend, calibri, helvetica;
 }
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
 
 div .txtblock {
-	margin:30px 0 48px 0;
+  margin:30px 0 48px 0;
 }
 
 .app-related-items {
@@ -52,13 +52,13 @@ div .txtblock {
 /* Top Nav */
 
 .topnav {
-	margin: auto;
+  margin: auto;
   overflow: hidden;
-	border-bottom: 1px solid #DBDBDB;
+  border-bottom: 1px solid #DBDBDB;
   //background-color: #ff9900;
-	position:relative;
-	padding:8px 8px 8px 16px;
-	text-decoration: none;
+  position:relative;
+  padding:8px 8px 8px 16px;
+  text-decoration: none;
 
 }
 
@@ -67,13 +67,13 @@ div .txtblock {
   text-align: center;
   padding: 14px 12px;
   text-decoration: none;
-	font-size: 14px;
-	font-weight:600;
+  font-size: 14px;
+  font-weight:600;
 
 }
 
 .topnav a:visited {
-	color: #0D0E0E;
+  color: #0D0E0E;
 
 }
 
@@ -81,11 +81,11 @@ div .txtblock {
 .topnav a:hover {
   background-color: #fff;
   color:#1571FB;
-	text-decoration:underline;
-	border-top: solid 1px;
+  text-decoration:underline;
+  border-top: solid 1px;
 }
 .fill-grey {
-    fill: green;
+  fill: green;
 }
 .topnav a.active {
   background-color: #04AA6D;
@@ -94,18 +94,18 @@ div .txtblock {
 
 .topnav .tools
 {
-	font-family: Lexend;
-	font-style: normal;
-	font-weight: normal;
-	font-size: 14px;
-	line-height: 100%;
-	color: #414745;
+  font-family: Lexend;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 14px;
+  line-height: 100%;
+  color: #414745;
 }
 
 .divider-top-links
 {
-	background-image: url('../public/images/divider-top-links.svg');
-	background-repeat:no-repeat;background-position:4px
+  background-image: url('../public/images/divider-top-links.svg');
+  background-repeat:no-repeat;background-position:4px
 }
 
 
@@ -148,7 +148,7 @@ div .txtblock {
   cursor: pointer;
   -webkit-transition-duration: 0.4s; /* Safari */
   transition-duration: 0.4s;
-	border-radius: 5px;
+  border-radius: 5px;
 }
 
 
@@ -169,8 +169,8 @@ div .txtblock {
 }
 
 .button a {
-	color:#ffffff;
-	text-decoration: none;
+  color:#ffffff;
+  text-decoration: none;
 }
 
 /* H2 */
@@ -189,17 +189,17 @@ div .txtblock {
 
 
 govuk-breadcrumbs a{
-	font-weight:300;
+  font-weight:300;
 }
 
 .timestamp {
-	font-family: Lexend;
-	font-style: normal;
-	font-weight: normal;
-	font-size: 14px;
-	line-height: 100%;
-	color: #5E5E56;
-	padding-bottom:20px;
+  font-family: Lexend;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 14px;
+  line-height: 100%;
+  color: #5E5E56;
+  padding-bottom:20px;
 }
 .govuk-heading-xl {
   color: #0b0c0c;
@@ -216,64 +216,63 @@ govuk-breadcrumbs a{
 
 
 h1 {
-font-family: Lexend, calibri, helvetica;
-font-style: normal;
-font-weight: bold;
-font-size: 40px;
-line-height: 140%;
+  font-family: Lexend, calibri, helvetica;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 40px;
+  line-height: 140%;
 }
 
 h2 {
-font-family: Lexend, calibri, helvetica;
-font-style: normal;
-font-weight: bold;
-font-size: 30px;
-line-height: 160%;
-/* identical to box height, or 48px */
+  font-family: Lexend, calibri, helvetica;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 30px;
+  line-height: 160%;
+  /* identical to box height, or 48px */
 }
 
 h3{
-font-family: Lexend, calibri, helvetica;
-font-style: normal;
-font-weight: bold;
-font-size: 24px;
-margin-top: 0;
-margin-bottom:10px;
+  font-family: Lexend, calibri, helvetica;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 24px;
+  margin-top: 0;
+  margin-bottom:10px;
 
 }
 
 h3 a {
-font-family: Lexend, calibri, helvetica;
-font-size: 24px;
-line-height: 1.2;
+  font-family: Lexend, calibri, helvetica;
+  font-size: 24px;
+  line-height: 1.2;
 }
 
 p {
-font-family: Lexend, calibri, helvetica;
-font-style: normal;
-font-weight: normal;
-font-size: 18px;
-line-height:160%;
+  font-family: Lexend, calibri, helvetica;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 18px;
+  line-height:160%;
 }
 
 
 li {
-font-family: Lexend, calibri, helvetica;
-font-style: normal;
-font-weight: normal;
-font-size: 18px;
-line-height:160%;
-padding-left:8px;
+  font-family: Lexend, calibri, helvetica;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 18px;
+  line-height:160%;
+  padding-left:8px;
 }
 
 
 a {
-font-family: Lexend, calibri, helvetica;
-font-style: medium;
-font-weight: 600;
-font-size: 18px;
-line-height: 160%;
-color:#2E65B7;
+  font-family: Lexend, calibri, helvetica;
+  font-style: medium;
+  font-weight: 600;
+  line-height: 160%;
+  color:#2E65B7;
 }
 
 
@@ -293,11 +292,11 @@ a:active {
 }
 
 .active {
-	text-decoration:none;
-	padding:4px 4px 4px 8px ;
-	background-color:#F4E9D1;
-	font-weight: bold;
-	border-radius: 5px;
+  text-decoration:none;
+  padding:4px 4px 4px 8px ;
+  background-color:#F4E9D1;
+  font-weight: bold;
+  border-radius: 5px;
 }
 
 
@@ -305,42 +304,42 @@ a:active {
 
 
 input {
-	 height:40px
+  height:40px
 }
 
 
 .card p {
-	font-size:16px;
-	font-family: Lexend, calibri, helvetica;
-	line-height:24px;
+  font-size:16px;
+  font-family: Lexend, calibri, helvetica;
+  line-height:24px;
 }
 
 /* Lazy Load Styles */
 .card {
-	//display: inline-block;
-	//max-width: 20rem;
-	width: 99%;
-	margin: 1rem;
-	font-size: 30px;
-	text-decoration: none;
-	overflow: hidden;
-	transition: transform 0.1s ease-in-out, box-shadow 0.1s;
+  //display: inline-block;
+  //max-width: 20rem;
+  width: 99%;
+  margin: 1rem;
+  font-size: 30px;
+  text-decoration: none;
+  overflow: hidden;
+  transition: transform 0.1s ease-in-out, box-shadow 0.1s;
   padding: 16px;
-	height:240px;
-	box-shadow: 0 0 2rem -1rem rgba(0,0,0,0.3);
+  height:240px;
+  box-shadow: 0 0 2rem -1rem rgba(0,0,0,0.3);
   border-radius: 8px;
 
 }
 
 .no-border {
-	margin: 1rem;
-	font-size: 30px;
-	text-decoration: none;
-	overflow: hidden;
-	transition: transform 0.1s ease-in-out, box-shadow 0.1s;
+  margin: 1rem;
+  font-size: 30px;
+  text-decoration: none;
+  overflow: hidden;
+  transition: transform 0.1s ease-in-out, box-shadow 0.1s;
   padding: 16px;
   border-radius: 8px;
-	height:240px;
+  height:240px;
 }
 
 .card:hover {
@@ -368,11 +367,13 @@ input {
   overflow: hidden;
   background-color: #E40037;
   padding: 2px 5px 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
 }
 
 /* Style the header links */
 .header a {
-  float: left;
   color: black;
   text-align: center;
   padding: 12px;
@@ -385,24 +386,24 @@ input {
 
 .key
 {
-	background: #F3F2F1;
-	padding:24px;
-	border-radius: 8px;
-	background-image: url('../../public/images/icons/key-info.svg');
-	background-position: 16px 16px;
-	background-repeat:no-repeat;
+  background: #F3F2F1;
+  padding:24px;
+  border-radius: 8px;
+  background-image: url('../../public/images/icons/key-info.svg');
+  background-position: 16px 16px;
+  background-repeat:no-repeat;
 }
 
 
 .calculator{
-	background: #F2EEF4;
-	//border-color:#F3F2F1;
-	//border: solid 3px #DDDDDD;
-	padding:24px;
-	border-radius: 8px;
-	background-image: url('../../public/images/icons/icon-calculator.svg');
-	background-position: 16px 16px;
-	background-repeat:no-repeat;
+  background: #F2EEF4;
+  //border-color:#F3F2F1;
+  //border: solid 3px #DDDDDD;
+  padding:24px;
+  border-radius: 8px;
+  background-image: url('../../public/images/icons/icon-calculator.svg');
+  background-position: 16px 16px;
+  background-repeat:no-repeat;
 
 }
 
@@ -432,7 +433,6 @@ input {
 /* Add media queries for responsiveness - when the screen is 500px wide or less, stack the links on top of each other */
 @media screen and (max-width: 500px) {
   .header a {
-    float: none;
     display: block;
     text-align: left;
   }
@@ -450,11 +450,11 @@ input {
 }
 .govuk-radios__item
 {
-	border-color:#ff9900;
+  border-color:#ff9900;
 }
 .govuk-label
 {
-	font-family: Lexend, calibri, helvetica;
+  font-family: Lexend, calibri, helvetica;
 }
 form.example input[type=text] {
   padding: 10px;
@@ -472,7 +472,7 @@ form.example button {
   background: #3D2E3A;
   color: white;
   font-size: 17px;
-	height:40px;
+  height:40px;
   border: 0px solid grey;
   border-left: none;
   cursor: pointer;

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -143,7 +143,6 @@ div .txtblock {
   text-align: center;
   text-decoration: none;
   display: inline-block;
-  font-size: 18px;
   margin: 4px 2px;
   cursor: pointer;
   -webkit-transition-duration: 0.4s; /* Safari */
@@ -171,6 +170,16 @@ div .txtblock {
 .button a {
   color:#ffffff;
   text-decoration: none;
+}
+
+#myOracle {
+  display: flex;
+  align-items: center;
+}
+
+.link-with-arrow {
+  display: flex;
+  align-items: center;
 }
 
 /* H2 */
@@ -207,8 +216,6 @@ govuk-breadcrumbs a{
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight:900;
-  font-size: 44px;
-  line-height: 1.09375;
   display: block;
   margin-top: 0;
   margin-bottom: 24px;
@@ -252,8 +259,6 @@ p {
   font-family: Lexend, calibri, helvetica;
   font-style: normal;
   font-weight: normal;
-  font-size: 18px;
-  line-height:160%;
 }
 
 
@@ -261,8 +266,6 @@ li {
   font-family: Lexend, calibri, helvetica;
   font-style: normal;
   font-weight: normal;
-  font-size: 18px;
-  line-height:160%;
   padding-left:8px;
 }
 
@@ -271,11 +274,8 @@ a {
   font-family: Lexend, calibri, helvetica;
   font-style: medium;
   font-weight: 600;
-  line-height: 160%;
   color:#2E65B7;
 }
-
-
 
 a:visited {
   color: #2E65b7;
@@ -298,10 +298,6 @@ a:active {
   font-weight: bold;
   border-radius: 5px;
 }
-
-
-
-
 
 input {
   height:40px

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -28,6 +28,11 @@ $govuk-font-family: Lexend, "HelveticaNeue", "Helvetica Neue", "Arial", "Helveti
   padding-right:4px;
 }
 
+.grid-with-icons .card img {
+  height: 45px;
+  width: auto;
+}
+
 body {
   font-family: Lexend, calibri, helvetica;
 }
@@ -327,12 +332,19 @@ input {
 
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 641px) {
   .card {
     margin: 1rem;
-    height:240px;
+    height: 240px;
   }
 }
+
+@media screen and (min-width: 768px) {
+  .card {
+    height: 270px;
+  }
+}
+
 
 .no-border {
   font-size: 30px;
@@ -341,7 +353,6 @@ input {
   transition: transform 0.1s ease-in-out, box-shadow 0.1s;
   padding: 16px;
   border-radius: 8px;
-  height:240px;
 }
 
 .card:hover {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -315,20 +315,26 @@ input {
   //display: inline-block;
   //max-width: 20rem;
   width: 99%;
-  margin: 1rem;
   font-size: 30px;
+  margin: 1rem 0;
   text-decoration: none;
   overflow: hidden;
   transition: transform 0.1s ease-in-out, box-shadow 0.1s;
   padding: 16px;
-  height:240px;
+  min-height: 180px;
   box-shadow: 0 0 2rem -1rem rgba(0,0,0,0.3);
   border-radius: 8px;
 
 }
 
+@media screen and (min-width: 768px) {
+  .card {
+    margin: 1rem;
+    height:240px;
+  }
+}
+
 .no-border {
-  margin: 1rem;
   font-size: 30px;
   text-decoration: none;
   overflow: hidden;

--- a/app/assets/sass/search-container.scss
+++ b/app/assets/sass/search-container.scss
@@ -1,40 +1,49 @@
-
 .search-container {
 
-    &__form {
-
-      display: flex;
-      flex-direction: row;
-    }
-
-    &__button {
-
-      background: #414745;
-      font-family: "Lexend", roboto, oxygen, ubuntu, cantarell, "Helvetica Neue", sans-serif;
-      color: #FFFFFF;
-      padding: 15px 40px 15px 20px;
-
-      border: 0;
-      // font-weight: bold;
-      font-size: 1.1rem;
-
-      background-image: url('../images/icons/search-icon.svg');
-      background-repeat: no-repeat;
-      background-position: calc(100% - 20px) center;
-      min-width: 150px;
-    }
-
-    &__input {
-
-
-      padding: 15px 20px;
-      border: 0;
-      background-color: #ffffff;
-      border-radius: 0px;
-
-      font-size: 1.1rem;
-      width: 100%;
-      height: auto;
-    }
-  
+  &__form {
+    display: flex;
+    flex-direction: row;
   }
+
+  &__button {
+    display: flex;
+    align-items: center;
+    background: #414745;
+    font-family: "Lexend", roboto, oxygen, ubuntu, cantarell, "Helvetica Neue", sans-serif;
+    color: #FFFFFF;
+    padding: 0.75rem 1rem;
+
+    border: 0;
+    // font-weight: bold;
+    font-size: 1.1rem;
+
+    img {
+      margin-left: 0.5rem;
+      height: 1.1rem;
+      width: 1.1rem;
+    }
+  }
+
+  &__input {
+    padding: 0.75rem 1rem;
+    border: 0;
+    background-color: #ffffff;
+    border-radius: 0px;
+    font-size: 1.1rem;
+    width: 100%;
+    height: auto;
+  }
+
+}
+
+
+@media screen and (max-width: 768px) {
+  .search-container {
+    &__input, &__button {
+      padding: 0.5rem 0.75rem;
+    }
+    &__button {
+      min-width: auto;
+    }
+  }
+}

--- a/app/views/book-leave.html
+++ b/app/views/book-leave.html
@@ -116,47 +116,7 @@ This year, the Christmas shut down day is 28 December 2022. </p>
 
     <div class="govuk-grid-column-one-third">
 
-      <aside class="app-related-items" role="complementary">
-        <h2 class="govuk-heading-m" id="subsection-title">
-          In this section
-        </h2>
-        <nav role="navigation" aria-labelledby="subsection-title">
-          <ul class="govuk-list">
-            <li class="active">
-              Book annual leave
-            </li>
-
-            <li>
-              <a href="#">
-                Change annual leave
-              </a>
-            </li>
-
-            <li>
-              <a href="buy-leave">
-                Buy more annual leave
-              </a>
-            </li>
-
-
-            <li>
-              <a href="#">
-                Carry over annual leave
-              </a>
-            </li>
-            <li>
-              <a href="leave-allowance">
-                Annual leave allowance
-              </a>
-            </li>
-
-
-
-
-          </ul>
-        </nav>
-      </aside>
-
+      {% include "includes/in-this-section.html" %}
       {% include "includes/contact-help.html" %}
     </div>
   </div>

--- a/app/views/book-leave.html
+++ b/app/views/book-leave.html
@@ -25,7 +25,6 @@
 {% endblock %}
 
 
-
 {% block content %}
 
   <div class="govuk-grid-row">
@@ -36,9 +35,9 @@
       <h1 class="govuk-heading-xl">
         Book annual leave
       </h1>
-      <p>All employees must book annual leave through <b>My Oracle</b>, except teachers and term-time employees. Sign in and select ‘Time and absences’ then ‘Add absence’.</p>
+      <p class='govuk-body'>All employees must book annual leave through <b>My Oracle</b>, except teachers and term-time employees. Sign in and select ‘Time and absences’ then ‘Add absence’.</p>
 
-      <button class="button button2" style="margin-bottom:30px">
+      <button id='myOracle' class="button button2 govuk-body" style="margin-bottom:30px">
         <a href="https://fa-epwc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/faces/FndOverview?fndGlobalItemNodeId=itemNode_my_information_absences1" target="_blank">Sign in to book annual leave</a>
         <img class="" alt="" style="width: 24px;margin-left:12px;padding-top:0px" src="public/images/icons/external-link-icon.svg" >
       </button>
@@ -49,7 +48,7 @@
 
   <div class="txtblock key">
       <h3 style="padding-left:50px">Key information</h3>
-      <ul class="">
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-5">
         <li>See how much annual leave you have left through <b>My Oracle</b>.</li>
         <li> <a href="leave-allowance">Check your total annual leave days</a> here on the intranet</li>
         <li>You can <a href="buy-leave">buy up to 5 more days annual leave</a> every year</li>
@@ -57,25 +56,29 @@
         <li>You must keep your annual leave balance up to date</li>
       </ul>
 
-      <img alt="" src="public/images/icons/arrow.svg" style="margin:10px 10px 0 20px;">
-      <a href="public//images/Holiday_policy.pdf" target="_blank">Read our annual leave policy </a>
+      <div class='link-with-arrow govuk-body'>
+        <img alt="" src="public/images/icons/arrow.svg" class="govuk-!-margin-right-2">
+        <a href="public//images/Holiday_policy.pdf" target="_blank">Read our annual leave policy </a>
+      </div>
   </div>
   <!-- Block text ends -->
 
   <!-- Block text starts -->
   <div class="txtblock">
-      <h2>Bank holidays</h2>
+      <h2 class='govuk-heading-l'>Bank holidays</h2>
       <p><b>Full-time employees</b> do not need to book bank holidays as annual leave.</p>
       <p><b>Part-time employees</b> who work fewer than 37 hours a week have a bank holiday allowance included in their annual leave entitlement for holiday.</p>
       <p>If you work part-time, you should book annual leave on any bank holiday that falls on a day you would usually work.</p>
-      <img alt="" src="public/images/icons/arrow.svg" style="margin:4px 10px 0 0px;">
-      <a href="https://www.gov.uk/bank-holidays" target="_blank">Check the upcoming bank holidays on GOV.UK</a>
+      <div class='link-with-arrow govuk-body'>
+        <img alt="" src="public/images/icons/arrow.svg" style="margin:4px 10px 0 0px;">
+        <a href="https://www.gov.uk/bank-holidays" target="_blank">Check the upcoming bank holidays on GOV.UK</a>
+      </div>
   </div>
   <!-- Block text ends -->
 
   <!-- Block text starts -->
   <div class="txtblock">
-      <h2>Christmas shutdown day</h2>
+      <h2 class='govuk-heading-l'>Christmas shutdown day</h2>
       <p>You must book Christmas shutdown day as annual leave through <b>My Oracle</b> if it falls on a day you would normally work.
 Christmas shutdown day is already included in your annual leave balance.
 This year, the Christmas shut down day is 28 December 2022. </p>
@@ -87,7 +90,7 @@ This year, the Christmas shut down day is 28 December 2022. </p>
 
   <!-- Block text starts -->
   <div class="txtblock">
-      <h2>Before you book</h2>
+      <h2 class='govuk-heading-l'>Before you book</h2>
       <p>While you don’t have to, employees often speak to their manager before booking annual leave. It helps them work with you and the team to plan ahead for when you are away from work. Your manager can also book your annual leave for you.
       </p>
   </div>
@@ -118,7 +121,7 @@ This year, the Christmas shut down day is 28 December 2022. </p>
           In this section
         </h2>
         <nav role="navigation" aria-labelledby="subsection-title">
-          <ul class="govuk-list govuk-!-font-size-16">
+          <ul class="govuk-list">
             <li class="active">
               Book annual leave
             </li>

--- a/app/views/book-leave.html
+++ b/app/views/book-leave.html
@@ -47,7 +47,7 @@
   <!-- Block text starts -->
 
   <div class="txtblock key">
-      <h3 style="padding-left:50px">Key information</h3>
+      <h3 style="padding-left:50px" class='govuk-heading-m'>Key information</h3>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-5">
         <li>See how much annual leave you have left through <b>My Oracle</b>.</li>
         <li> <a href="leave-allowance">Check your total annual leave days</a> here on the intranet</li>

--- a/app/views/buy-leave.html
+++ b/app/views/buy-leave.html
@@ -41,20 +41,20 @@
   <!-- Block text starts -->
 
   <div class="txtblock">
-      <p>
+      <p class='govuk-body'>
       You can buy up to 5 days (37 hours) extra annual leave each year. If you work part-time, the maximum hours you can ask for is the same as the weekly hours in your contract. If you are on a term-time contract or have a contract that is less than 12 months, you are not eligible to buy more annual leave.</p>
 
 
-        <p>You can only buy leave between the following dates each year: </p>
+        <p class='govuk-body'>You can only buy leave between the following dates each year: </p>
 
-        <ul class="">
+        <ul class="govuk-list govuk-list--bullet">
           <li>1 to 24 March</li>
           <li>1 September to 31 October</li>
         </ul>
-        <button class="button button2">
+        <button id='myOracle' class="button button2 govuk-body">
           <a href="https://fa-epwc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/faces/FndOverview?fndGlobalItemNodeId=itemNode_my_information_absences1" target="_blank">
           Buy more annual leave on My Oracle</a>
-          <img class="" style="width: 24px;margin-left:12px;padding-top:0px" src="public/images/icons/external-link-icon.svg">
+          <img class="" alt='' style="width: 24px;margin-left:12px;padding-top:0px" src="public/images/icons/external-link-icon.svg">
         </button>
   </div>
 
@@ -62,12 +62,12 @@
 
 <!-- Block Calculator starts -->
 
-  <div class="txtblock calculator"  style="" >
+  <div class="txtblock calculator">
 
   <form id="form">
     <div>
-      <h3 style="padding-left:50px">Buying annual leave cost calculator</h3>
-      <p >Use this calculator to work out the total cost and cost per day of buying more annual leave.</p>
+      <h3 style="padding-left:50px" class='govuk-heading-m'>Buying annual leave cost calculator</h3>
+      <p class='govuk-!-margin-top-5'>Use this calculator to work out the total cost and cost per day of buying more annual leave.</p>
 
       <label>
         <p>What is your salary?</p>
@@ -90,7 +90,7 @@
     </div>
 
 <p></p>
-    <input type="submit" value="Calculate" class="button button2" style="height:50px">
+    <input type="submit" value="Calculate" class="button button2 govuk-body" style="height:50px">
 
   </form>
   <p></p>
@@ -104,8 +104,8 @@
 <!-- Block text starts -->
 
 <div class="txtblock key">
-  <h3 style="padding-left:50px">Key information</h3>
-  <ul class="">
+  <h3 style="padding-left:50px" class='govuk-heading-m'>Key information</h3>
+  <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-5">
     <li>You give up or 'sacrifice' part of your salary in exchange for more annual leave, this is known as a salary sacrifice arrangement</li>
     <li>Payments are made from your gross salary, so you pay no tax or national insurance on the value of the extra annual leave</li>
     <li>As the cost of buying more annual leave comes out of your salary before tax is deducted, your amount of pensionable pay will be reduced</li>
@@ -121,9 +121,12 @@
 
   <!-- Block text starts -->
   <div class="txtblock">
-      <h2>Guidance for line managers</h2>
-      <a href="public/images/Holiday_buying_additional_line_manager_guide.pdf" target="_blank" >
-      <img src="public/images/icons/arrow.svg" style="margin:0px 8px 0 0">View and download pdf guidance</a>
+      <h2 class='govuk-heading-l'>Guidance for line managers</h2>
+      <div class='link-with-arrow govuk-body'>
+        <img src="public/images/icons/arrow.svg" style="margin:0px 8px 0 0">
+        <a href="public/images/Holiday_buying_additional_line_manager_guide.pdf" target="_blank" >
+        View and download pdf guidance</a>
+        </div>
   </div>
   <!-- Block text ends -->
 
@@ -152,8 +155,5 @@
   </div>
 
 <div style="height:80px"></div>
-
-
-
 
 {% endblock %}

--- a/app/views/buy-leave.html
+++ b/app/views/buy-leave.html
@@ -145,48 +145,7 @@
 
     </div>
     <div class="govuk-grid-column-one-third">
-
-      <aside class="app-related-items" role="complementary">
-        <h2 class="govuk-heading-m" id="subsection-title">
-          In this section
-        </h2>
-        <nav role="navigation" aria-labelledby="subsection-title">
-          <ul class="govuk-list govuk-!-font-size-16">
-            <li>
-              <a href="book-leave">
-                Book annual leave
-              </a>
-            </li>
-
-            <li>
-              <a href="#">
-                Change annual leave
-              </a>
-            </li>
-
-            <li class="active">
-
-                Buy more annual leave
-
-            </li>
-
-
-            <li>
-              <a href="#">
-                Carry over annual leave
-              </a>
-            </li>
-            <li>
-              <a href="leave-allowance">
-                Annual leave allowance
-              </a>
-            </li>
-
-
-          </ul>
-        </nav>
-      </aside>
-
+      {% include "includes/in-this-section.html" %}
       {% include "includes/contact-help.html" %}
     </div>
 

--- a/app/views/includes/header.html
+++ b/app/views/includes/header.html
@@ -3,5 +3,5 @@
   <a href="index" class="logo">
     <img alt="Essex County Council" style="width: 240px" src="public/images/ecc_logo.svg">
   </a>
-  <p style="font-size:22px;padding-top:10px">intranet</p>
+  <p class="govuk-body govuk-!-margin-0">intranet</p>
 </div>

--- a/app/views/includes/hero.html
+++ b/app/views/includes/hero.html
@@ -1,5 +1,3 @@
-
-
 <!-- Hero begins -->
 <div class="hero">
   <div class="govuk-width-container">
@@ -10,7 +8,8 @@
                     <form action="" class="search-container__form">
                       <input type="text" placeholder="Search.." name="search" class="search-container__input">
                       <button type="submit" class="search-container__button">
-                        Submit
+                        <span>Submit</span>
+                        <img alt='' src='/public/images/icons/search-icon.svg'>
                       </button>
                     </form>
                   </div>

--- a/app/views/includes/in-this-section.html
+++ b/app/views/includes/in-this-section.html
@@ -1,0 +1,36 @@
+<aside class="app-related-items" role="complementary">
+  <h2 class="govuk-heading-m" id="subsection-title">
+    In this section
+  </h2>
+  <nav role="navigation" aria-labelledby="subsection-title">
+    <ul class="govuk-list">
+      <li class="active">
+        Book annual leave
+      </li>
+
+      <li>
+        <a href="#">
+          Change annual leave
+        </a>
+      </li>
+
+      <li>
+        <a href="buy-leave">
+          Buy more annual leave
+        </a>
+      </li>
+
+
+      <li>
+        <a href="#">
+          Carry over annual leave
+        </a>
+      </li>
+      <li>
+        <a href="leave-allowance">
+          Annual leave allowance
+        </a>
+      </li>
+    </ul>
+  </nav>
+</aside>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,221 +1,206 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Essex Intranet Prototype
+Essex Intranet Prototype
 {% endblock %}
 
 
 {% block content %}
 <div class="govuk-grid-row" style="background-color:#fff">
-<!-- Tile begins-->
-  <div class="govuk-grid-column-one-quarter">
+  <!-- Tile begins-->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img class="" style="width: 54px" src="public/images/icons/learning.svg">
-        <h3><a class="card-description" href="#">Learning and development</a></h3>
-        <p>Resources to help you grow and develop your career</p>
-      </div>
+      <img alt="" style="width: 54px" src="public/images/icons/learning.svg">
+      <h3><a class="card-description" href="#">Learning and development</a></h3>
+      <p>Resources to help you grow and develop your career</p>
+    </div>
   </div>
-<!-- Tile ends-->
+  <!-- Tile ends-->
 
-<!-- Tile begins-->
-  <div class="govuk-grid-column-one-quarter">
+  <!-- Tile begins-->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card no-border">
-      <img class="" style="width: 44px" src="public/images/icons/expenses.svg">
+      <img alt="" style="width: 44px" src="public/images/icons/expenses.svg">
       <div class="container">
         <h3><a class="card-description" href="#">Pay, records and expenses</a></h3>
         <p>View your payslip, employment record and submit expenses</p>
       </div>
     </div>
   </div>
-<!-- Tile ends-->
+  <!-- Tile ends-->
 
-<!-- Tile begins-->
-  <div class="govuk-grid-column-one-quarter">
+  <!-- Tile begins-->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img class="" style="width: 58px" src="public/images/icons/recruitment.svg">
+      <img alt="" style="width: 58px" src="public/images/icons/recruitment.svg">
       <div class="container">
         <h3>
-          <a class="card-description" href="#">
-          Recruitment</a></h3>
-          <p>Line manager's guide to recruitment</p>
+          <a class="card-description" href="#">Recruitment</a>
+        </h3>
+        <p>Line manager's guide to recruitment</p>
       </div>
     </div>
   </div>
-<!-- Tile ends-->
+  <!-- Tile ends-->
 
 
-<!-- Tile begins-->
-  <div class="govuk-grid-column-one-quarter">
+  <!-- Tile begins-->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img class="" style="width: 44px" src="public/images/icons/careers.svg">
+      <img alt="" style="width: 44px" src="public/images/icons/careers.svg">
       <div class="container">
         <h3>
           <a class="card-description" href="#">
-          Ways of working</a></h3>
-          <p>Information on our new hybrid working model</p>
+            Ways of working</a></h3>
+        <p>Information on our new hybrid working model</p>
       </div>
     </div>
   </div>
-<!-- Tile ends-->
+  <!-- Tile ends-->
 
-<!-- Tile begins-->
-  <div class="govuk-grid-column-one-quarter">
+  <!-- Tile begins-->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img class="" style="width: 50px" src="public/images/icons/book-meeting-room.svg">
-        <h3><a class="card-description" href="#">Book a room</a></h3>
-        <p>How to book a meeting room in our offices and other venues</p>
-      </div>
+      <img alt="" style="width: 50px" src="public/images/icons/book-meeting-room.svg">
+      <h3><a class="card-description" href="#">Book a room</a></h3>
+      <p>How to book a meeting room in our offices and other venues</p>
+    </div>
   </div>
-<!-- Tile ends -->
+  <!-- Tile ends -->
 
 
-<!-- Tile begins-->
-  <div class="govuk-grid-column-one-quarter">
+  <!-- Tile begins-->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img class="" style="width: 54px" src="public/images/icons/time-off-2.svg">
+      <img alt="" style="width: 54px" src="public/images/icons/time-off-2.svg">
       <div class="container">
         <h3>
           <a class="card-description" href="level-01.html">
-          Annual leave<br>and time off</a></h3>
-          <p>Information on annual leave, sickness and other time off</p>
+            Annual leave<br>and time off</a></h3>
+        <p>Information on annual leave, sickness and other time off</p>
       </div>
     </div>
   </div>
-<!-- Tile ends-->
+  <!-- Tile ends-->
 
-
-<!-- Tile begins
-<div class="govuk-grid-column-one-quarter">
-  <div class="card">
-
-    <img class="" style="width: 54px" src="public/images/icons/phone.svg">
-    <div class="container">
-      <h3><a class="card-description" href="#">Employee directory</a></h3>
-      <p>Find out more about...</p>
+  <!-- Tile begins-->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
+    <div class="card">
+      <img alt="" style="width: 54px" src="public/images/icons/flexible-working.svg">
+      <h3><a class="card-description" href="#">Travel for work</a></h3>
+      <p>Travel options, discounts and how to book travel or accommodation for work</p>
     </div>
   </div>
-</div>
-<!-- Tile ends-->
+  <!-- Tile ends -->
 
-<!-- Tile begins-->
-  <div class="govuk-grid-column-one-quarter">
-    <div class="card">
-      <img class="" style="width: 54px" src="public/images/icons/flexible-working.svg">
-        <h3><a class="card-description" href="#">Travel for work</a></h3>
-        <p>Travel options, discounts and how to book travel or accommodation for work</p>
-      </div>
-  </div>
-<!-- Tile ends -->
-
-<!-- Tile begins-->
-  <div class="govuk-grid-column-one-quarter">
+  <!-- Tile begins-->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
 
-      <img class="" style="width: 54px" src="public/images/icons/covid.svg">
+      <img alt="" style="width: 54px" src="public/images/icons/covid.svg">
       <div class="container">
         <h3><a class="card-description" href="#">Covid-19 information and support</a></h3>
         <p>Latest coronavirus advice and guidance</p>
       </div>
     </div>
   </div>
-<!-- Tile ends-->
+  <!-- Tile ends-->
 
 
-<!-- Tile begins-->
-
-<div class="govuk-grid-column-one-quarter">
-  <div class="card">
-    <img class="" style="width: 54px" src="public/images/icons/buying.svg">
+  <!-- Tile begins-->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
+    <div class="card">
+      <img alt="" style="width: 54px" src="public/images/icons/buying.svg">
       <h3><a class="card-description" href="#">Buying goods<br>and services</a></h3>
       <p>How to buy goods, services and work equipment</p>
     </div>
-</div>
-<!-- Tile ends-->
-
-<!-- Tile begins-->
-  <div class="govuk-grid-column-one-quarter">
-    <div class="card">
-      <img class="" style="width:50px" src="public/images/icons/pay-and-benefits-2.svg">
-        <h3><a class="card-description" href="#">Benefits<br>and rewards</a></h3>
-        <p>Information on benefits, discounts and rewards</p>
-      </div>
   </div>
-<!-- Tile ends -->
+  <!-- Tile ends-->
 
-<!-- Tile begins -->
-    <div class="govuk-grid-column-one-quarter">
-      <div class="card">
-        <img class="" style="width: 54px" src="public/images/icons/pension.svg">
-          <h3><a class="card-description" href="#">Pensions and retirement</a></h3>
-          <p>Your pension and retirement options</p>
-        </div>
-    </div>
-<!-- Tile ends -->
-
-<!-- Tile begins-->
-  <div class="govuk-grid-column-one-quarter">
+  <!-- Tile begins-->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img class="" style="width: 56px" src="public/images/icons/people.svg">
+      <img alt="" style="width:50px" src="public/images/icons/pay-and-benefits-2.svg">
+      <h3><a class="card-description" href="#">Benefits<br>and rewards</a></h3>
+      <p>Information on benefits, discounts and rewards</p>
+    </div>
+  </div>
+  <!-- Tile ends -->
+
+  <!-- Tile begins -->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
+    <div class="card">
+      <img alt="" style="width: 54px" src="public/images/icons/pension.svg">
+      <h3><a class="card-description" href="#">Pensions and retirement</a></h3>
+      <p>Your pension and retirement options</p>
+    </div>
+  </div>
+  <!-- Tile ends -->
+
+  <!-- Tile begins-->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
+    <div class="card">
+      <img alt="" style="width: 56px" src="public/images/icons/people.svg">
       <div class="container">
         <h3><a class="card-description" href="#">Manage your team</a></h3>
         <p>Key information for line managers</p>
       </div>
     </div>
   </div>
-<!-- Tile ends-->
+  <!-- Tile ends-->
 
 
-<!-- Tile begins-->
-  <div class="govuk-grid-column-one-quarter">
+  <!-- Tile begins-->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img class="" style="width: 56px" src="public/images/icons/council.svg">
+      <img alt="" style="width: 56px" src="public/images/icons/council.svg">
       <div class="container">
         <h3><a class="card-description" href="#">About the council</a></h3>
         <p>Members, councillors, officers, functions and policies</p>
       </div>
     </div>
   </div>
-<!-- Tile ends-->
+  <!-- Tile ends-->
 
-<!-- Tile begins -->
-  <div class="govuk-grid-column-one-quarter">
+  <!-- Tile begins -->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img class="" style="width: 60px" src="public/images/icons/onboarding.svg">
+      <img alt="" style="width: 60px" src="public/images/icons/onboarding.svg">
       <div class="container">
         <h3><a class="card-description" href="#">New employees</a></h3>
         <p>Information for new starters</p>
       </div>
     </div>
   </div>
-<!-- Tile ends -->
+  <!-- Tile ends -->
 
-<!-- Tile begins -->
-    <div class="govuk-grid-column-one-quarter">
-      <div class="card">
-        <img class="" style="width: 54px" src="public/images/icons/help.svg">
-          <h3><a class="card-description" href="#">Help and support</a></h3>
-          <p>Help with the intranet, using My Oracle and IT</p>
-        </div>
+  <!-- Tile begins -->
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
+    <div class="card">
+      <img alt="" style="width: 54px" src="public/images/icons/help.svg">
+      <h3><a class="card-description" href="#">Help and support</a></h3>
+      <p>Help with the intranet, using My Oracle and IT</p>
     </div>
+  </div>
 
-<!-- Tile ends -->
+  <!-- Tile ends -->
 </div>
 <!-- Row ends -->
 
 <div class="govuk-grid-row" style="background-color:#fff">
-    <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-full">
 
-        <a href="https://onenews.essex.gov.uk/gavins-corner" target="_blank">
-        <img class="" style="margin-top:60px;margin-left:20px;width:100%" src="public/images/one-news.png">
-        </a>
+    <a href="https://onenews.essex.gov.uk/gavins-corner" target="_blank">
+      <img alt="" style="margin-top:60px;margin-left:20px;width:100%" src="public/images/one-news.png">
+    </a>
 
-    </div>
+  </div>
 
 </div>
 
 
 
-  <div style="height:80px"></div>
+<div style="height:80px"></div>
 
 
 {% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -6,11 +6,11 @@ Essex Intranet Prototype
 
 
 {% block content %}
-<div class="govuk-grid-row" style="background-color:#fff">
+<div class="govuk-grid-row grid-with-icons" style="background-color:#fff">
   <!-- Tile begins-->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width: 54px" src="public/images/icons/learning.svg">
+      <img alt="" src="public/images/icons/learning.svg">
       <h3><a class="card-description" href="#">Learning and development</a></h3>
       <p>Resources to help you grow and develop your career</p>
     </div>
@@ -20,7 +20,7 @@ Essex Intranet Prototype
   <!-- Tile begins-->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card no-border">
-      <img alt="" style="width: 44px" src="public/images/icons/expenses.svg">
+      <img alt="" src="public/images/icons/expenses.svg">
       <div class="container">
         <h3><a class="card-description" href="#">Pay, records and expenses</a></h3>
         <p>View your payslip, employment record and submit expenses</p>
@@ -32,7 +32,7 @@ Essex Intranet Prototype
   <!-- Tile begins-->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width: 58px" src="public/images/icons/recruitment.svg">
+      <img alt="" src="public/images/icons/recruitment.svg">
       <div class="container">
         <h3>
           <a class="card-description" href="#">Recruitment</a>
@@ -47,7 +47,7 @@ Essex Intranet Prototype
   <!-- Tile begins-->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width: 44px" src="public/images/icons/careers.svg">
+      <img alt="" src="public/images/icons/careers.svg">
       <div class="container">
         <h3>
           <a class="card-description" href="#">
@@ -61,7 +61,7 @@ Essex Intranet Prototype
   <!-- Tile begins-->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width: 50px" src="public/images/icons/book-meeting-room.svg">
+      <img alt="" src="public/images/icons/book-meeting-room.svg">
       <h3><a class="card-description" href="#">Book a room</a></h3>
       <p>How to book a meeting room in our offices and other venues</p>
     </div>
@@ -72,7 +72,7 @@ Essex Intranet Prototype
   <!-- Tile begins-->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width: 54px" src="public/images/icons/time-off-2.svg">
+      <img alt="" src="public/images/icons/time-off-2.svg">
       <div class="container">
         <h3>
           <a class="card-description" href="level-01.html">
@@ -86,7 +86,7 @@ Essex Intranet Prototype
   <!-- Tile begins-->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width: 54px" src="public/images/icons/flexible-working.svg">
+      <img alt="" src="public/images/icons/flexible-working.svg">
       <h3><a class="card-description" href="#">Travel for work</a></h3>
       <p>Travel options, discounts and how to book travel or accommodation for work</p>
     </div>
@@ -97,7 +97,7 @@ Essex Intranet Prototype
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
 
-      <img alt="" style="width: 54px" src="public/images/icons/covid.svg">
+      <img alt="" src="public/images/icons/covid.svg">
       <div class="container">
         <h3><a class="card-description" href="#">Covid-19 information and support</a></h3>
         <p>Latest coronavirus advice and guidance</p>
@@ -110,7 +110,7 @@ Essex Intranet Prototype
   <!-- Tile begins-->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width: 54px" src="public/images/icons/buying.svg">
+      <img alt="" src="public/images/icons/buying.svg">
       <h3><a class="card-description" href="#">Buying goods<br>and services</a></h3>
       <p>How to buy goods, services and work equipment</p>
     </div>
@@ -120,7 +120,7 @@ Essex Intranet Prototype
   <!-- Tile begins-->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width:50px" src="public/images/icons/pay-and-benefits-2.svg">
+      <img alt="" src="public/images/icons/pay-and-benefits-2.svg">
       <h3><a class="card-description" href="#">Benefits<br>and rewards</a></h3>
       <p>Information on benefits, discounts and rewards</p>
     </div>
@@ -130,7 +130,7 @@ Essex Intranet Prototype
   <!-- Tile begins -->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width: 54px" src="public/images/icons/pension.svg">
+      <img alt="" src="public/images/icons/pension.svg">
       <h3><a class="card-description" href="#">Pensions and retirement</a></h3>
       <p>Your pension and retirement options</p>
     </div>
@@ -140,7 +140,7 @@ Essex Intranet Prototype
   <!-- Tile begins-->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width: 56px" src="public/images/icons/people.svg">
+      <img alt="" src="public/images/icons/people.svg">
       <div class="container">
         <h3><a class="card-description" href="#">Manage your team</a></h3>
         <p>Key information for line managers</p>
@@ -153,7 +153,7 @@ Essex Intranet Prototype
   <!-- Tile begins-->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width: 56px" src="public/images/icons/council.svg">
+      <img alt="" src="public/images/icons/council.svg">
       <div class="container">
         <h3><a class="card-description" href="#">About the council</a></h3>
         <p>Members, councillors, officers, functions and policies</p>
@@ -165,7 +165,7 @@ Essex Intranet Prototype
   <!-- Tile begins -->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width: 60px" src="public/images/icons/onboarding.svg">
+      <img alt="" src="public/images/icons/onboarding.svg">
       <div class="container">
         <h3><a class="card-description" href="#">New employees</a></h3>
         <p>Information for new starters</p>
@@ -177,7 +177,7 @@ Essex Intranet Prototype
   <!-- Tile begins -->
   <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
     <div class="card">
-      <img alt="" style="width: 54px" src="public/images/icons/help.svg">
+      <img alt="" src="public/images/icons/help.svg">
       <h3><a class="card-description" href="#">Help and support</a></h3>
       <p>Help with the intranet, using My Oracle and IT</p>
     </div>

--- a/app/views/leave-allowance.html
+++ b/app/views/leave-allowance.html
@@ -248,52 +248,12 @@ Leave allowance - Essex Intranet Prototype
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <aside class="app-related-items" role="complementary">
-      <h2 class="govuk-heading-m" id="subsection-title">
-        In this section
-      </h2>
-      <nav role="navigation" aria-labelledby="subsection-title">
-        <ul class="govuk-list govuk-!-font-size-16">
-          <li>
-            <a href="book-leave">
-              Book annual leave
-            </a>
-          </li>
-
-          <li>
-            <a href="#">
-              Change annual leave
-            </a>
-          </li>
-
-          <li>
-            <a href="buy-leave" class="govuk-!-font-weight-bold">
-              Buy more annual leave
-            </a>
-          </li>
-
-
-          <li>
-            <a href="#">
-              Carry over annual leave
-            </a>
-          </li>
-          <li class="active">
-            Annual leave allowance
-          </li>
-
-        </ul>
-      </nav>
-    </aside>
-
+    {% include "includes/in-this-section.html" %}
     {% include "includes/contact-help.html" %}
   </div>
 
 </div>
 
 <div style="height:80px"></div>
-
-
-
 
 {% endblock %}

--- a/app/views/leave-allowance.html
+++ b/app/views/leave-allowance.html
@@ -44,7 +44,7 @@ Leave allowance - Essex Intranet Prototype
       How much annual leave you get is written in your contract.
       <br>It depends on:
       </p>
-      <ul class="">
+      <ul class="govuk-list govuk-list--bullet">
         <li>conditions of service</li>
         <li>salary</li>
         <li>length of service.</li>
@@ -63,7 +63,7 @@ Leave allowance - Essex Intranet Prototype
         <form id="form">
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-              <h3 style="padding-left:50px">Holiday allowance calculator</h3>
+              <h3 style="padding-left:50px" class='govuk-heading-m'>Holiday allowance calculator</h3>
             </legend>
 
             <div class="govuk-radios" data-module="govuk-radios">
@@ -112,7 +112,7 @@ Leave allowance - Essex Intranet Prototype
 
           </fieldset>
 
-          <input type="submit" value="Continue" class="button button2 govuk-!-margin-top-4" style="height:50px">
+          <input type="submit" value="Continue" class="button button2 govuk-body govuk-!-margin-top-4" style="height:50px">
 
         </form>
       </div>
@@ -122,18 +122,18 @@ Leave allowance - Essex Intranet Prototype
 
     <!-- Block text starts -->
     <div class="txtblock">
-      <h2>Find out how much annual leave you currently have</h2>
+      <h2 class='govuk-heading-l'>Find out how much annual leave you currently have</h2>
       <p>You can check how much holiday you have on <b>My Oracle</b>.
       Sign in and select ‘Time and absences’ then ‘Absence balance’.</p>
 
       <p>Your absence balance is shown in hours and will include:</p>
-      <ul class="">
+      <ul class="govuk-list govuk-list--bullet">
         <li>any holiday hours that you have bought</li>
         <li>bank holiday hours if you work part-time</li>
         <li>a deduction for any approved annual leave</li>
       </ul>
 
-      <button class="button button2">
+      <button class="button button2 govuk-body" id='myOracle'>
         <a href="https://fa-epwc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/faces/FndOverview?fndGlobalItemNodeId=itemNode_my_information_absences1" target="_blank">
           Check annual leave allowance</a>
         <img alt="" style="width: 24px;margin-left:12px;padding-top:0px" src="public/images/icons/external-link-icon.svg">
@@ -141,13 +141,11 @@ Leave allowance - Essex Intranet Prototype
     </div>
     <!-- Block text ends -->
 
-
-
     <!-- Block accordion starts -->
-    <div id='accordion'>
+    <div id='accordion' class='govuk-!-margin-bottom-8'>
       <div class='accordion-section'>
         <div id='accordion-heading-1' class='accordion-heading'>
-          <h3>
+          <h3 class='govuk-heading-m'>
             Additional annual leave
           </h3>
           <div class='accordion-toggle'>
@@ -165,7 +163,7 @@ Leave allowance - Essex Intranet Prototype
 
       <div class='accordion-section'>
         <div id='accordion-heading-2' class='accordion-heading'>
-          <h3>
+          <h3 class='govuk-heading-m'>
             Annual leave and maternity or shared parental leave
           </h3>
           <div class='accordion-toggle'>
@@ -185,7 +183,7 @@ Leave allowance - Essex Intranet Prototype
 
       <div class='accordion-section'>
         <div id='accordion-heading-3' class='accordion-heading'>
-          <h3>
+          <h3 class='govuk-heading-m'>
             Annual leave for new starters
           </h3>
           <div class='accordion-toggle'>
@@ -205,7 +203,7 @@ Leave allowance - Essex Intranet Prototype
 
       <div class='accordion-section'>
         <div id='accordion-heading-4' class='accordion-heading'>
-          <h3>
+          <h3 class='govuk-heading-m'>
             Annual leave for leavers
           </h3>
           <div class='accordion-toggle'>
@@ -225,7 +223,7 @@ Leave allowance - Essex Intranet Prototype
 
       <div class='accordion-section'>
         <div id='accordion-heading-5' class='accordion-heading'>
-          <h3>
+          <h3 class='govuk-heading-m'>
             Illness while on annual leave
           </h3>
           <div class='accordion-toggle'>


### PR DESCRIPTION
This should fix a few issues with the mobile styles:

* Using the GOV.UK design system typography classes rather than setting pixel sizes
* Adding some media queries to change spacing on smaller screens
* Using flexbox where we have elements side-by-side (e.g. images next to text)
* Swapping out some background images for `<img>` elements that can be more easily styled